### PR TITLE
Add configuration for ssh-based GitHub auth

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -187,7 +187,8 @@ To clone GitHub repositories on the cluster over the `git+ssh` protocol, followi
 
 1. Configure your local ssh client as per the [GitHub documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
 2. Enable agent forwarding (if you use the ssh config above, this should already be done)
-3. Add following configuration to your ssh-config *on the cluster*. This will make sure that communication goes through the https proxy.
+3. Add following configuration to your ssh-config _on the cluster_. This will make sure that communication goes through the https proxy.
+
    ```sh
    $ cat ~/.ssh/config
    host github.com
@@ -199,7 +200,7 @@ To clone GitHub repositories on the cluster over the `git+ssh` protocol, followi
 
 To verify your setup, run following command:
 
-```
+```sh
 USER@g1-9:~$ ssh -T git@github.com
 Hi USER! You've successfully authenticated, but GitHub does not provide shell access.
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -183,22 +183,7 @@ Read operations on network storage (projects, groups) are cached transparently o
 
 ## GitHub Authentication through SSH
 
-To clone GitHub repositories on the cluster over the `git+ssh` protocol, following steps are needed:
-
-1. Configure your local ssh client as per the [GitHub documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
-2. Enable agent forwarding (if you use the ssh config above, this should already be done)
-3. Add following configuration to your ssh-config _on the cluster_. This will make sure that communication goes through the https proxy.
-
-   ```sh
-   $ cat ~/.ssh/config
-   host github.com
-     user git
-     hostname ssh.github.com
-     port 443
-     proxycommand socat - PROXY:proxy.ikim.uk-essen.de:%h:%p,proxyport=3128
-   ```
-
-To verify your setup, run following command:
+To clone GitHub repositories on the cluster over the `git+ssh` protocol, you need to (1) configure your local ssh client as per the [GitHub documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh), and (2) enable agent forwarding (if you use the ssh config above, this should already be done). You can verify your setup with following command:
 
 ```sh
 USER@g1-9:~$ ssh -T git@github.com

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -181,6 +181,29 @@ Here are tips on writing programs, scripts, containers, etc. that make good use 
 
 Read operations on network storage (projects, groups) are cached transparently on the local storage drive. Generally speaking, your first access to a dataset will be slower than usual due to the overhead of creating the cache, but any subsequent access will be made from local storage.
 
+## GitHub Authentication through SSH
+
+To clone GitHub repositories on the cluster over the `git+ssh` protocol, following steps are needed:
+
+1. Configure your local ssh client as per the [GitHub documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
+2. Enable agent forwarding (if you use the ssh config above, this should already be done)
+3. Add following configuration to your ssh-config *on the cluster*. This will make sure that communication goes through the https proxy.
+   ```sh
+   $ cat ~/.ssh/config
+   host github.com
+     user git
+     hostname ssh.github.com
+     port 443
+     proxycommand socat - PROXY:proxy.ikim.uk-essen.de:%h:%p,proxyport=3128
+   ```
+
+To verify your setup, run following command:
+
+```
+USER@g1-9:~$ ssh -T git@github.com
+Hi USER! You've successfully authenticated, but GitHub does not provide shell access.
+```
+
 ## Tips on Working with remote computing services
 
 - [Unix Crash Course](https://tildesites.bowdoin.edu/~sbarker/unix/)


### PR DESCRIPTION
gith+ssh authentication fails because of blocked ports. 

```
jan.trienes@g1-5:~$ ssh -T git@github.com
ssh: connect to host github.com port 22: Network is unreachable
```

We can configure git+ssh to go through the https proxy. This PR adds this configuration bit to the docs.