### PR TITLE
Edit list of required information

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,6 @@ ssh-keygen -t ed25519 -f ~/.ssh/id_ikim
 
 Please send the public key along with following contact details to your project coordinator:
 
-- Desired username (e.g., `firstname.lastname`)
 - First name
 - Last name
 - UK/UDE email


### PR DESCRIPTION
Users do not need to provide a desired username. The username should simply be picked by the administrator.  This way all user names follow the same naming convention.