### PR TITLE
simplify ssh config

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,9 +85,6 @@ Host ikim
 
 Host g1-? c? c?? slurmq
   Hostname %h.ikim.uk-essen.de
-  ForwardAgent yes
-
-Host g1-*.ikim.uk-essen.de c*.ikim.uk-essen.de slurmq.ikim.uk-essen.de
   User $USERNAME
   IdentityFile ~/.ssh/id_ikim
   ProxyJump ikim

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -101,20 +101,21 @@ The connection will transparently jump through the host labeled `ikim` and proce
 
 ### Test your SSH login
 
-Try the examples below to test that your SSH client is properly configured:
+Try the example below to test that your SSH client is properly configured:
 
 ```sh
 # Log into the slurm submission node
-ssh slurmq.ikim.uk-essen.de
-
-# Shorthand for above command
 ssh slurmq
 ```
 
-If any of the above is not working, please run the command below and send the debug message to your project coordinator for help.
+If the above is not working, please run the commands below and send the debug messages to your project coordinator for help.
 
 ```sh
-ssh -v $USERNAME@login.ikim.uk-essen.de
+ssh -v slurmq
+```
+
+```sh
+ssh -v ikim
 ```
 
 ### SSH clients on Windows


### PR DESCRIPTION
It seems that on some systems/version, the options for `Host g1-*.ikim.uk-essen.de c*.ikim.uk-essen.de slurmq.ikim.uk-essen.de` aren't applied after resolving the hostname via `Host g1-? c? c?? slurmq`. Hence I moved the inside `Host g1-? c? c?? slurmq` and removed the rest => shorter config and advanced users will adapt it to their needs anyway.