### PR TITLE
Add a page about using conda with slurm.

### DIFF
--- a/docs/conda.md
+++ b/docs/conda.md
@@ -1,0 +1,48 @@
+# Mamba/Conda
+
+[Mambaforge][mambaforge] provides `mamba` and `conda` on the cluster.
+Users who prefer to manage their own installation can install a Conda distribution in their home directory.
+
+## Using Conda with Slurm
+
+Submitting a slurm job which includes `conda activate` will result in the following error:
+
+```sh
+$ srun -N1 conda activate myenv
+
+CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.
+To initialize your shell, run
+
+    $ conda init <SHELL_NAME>
+```
+
+This happens because `conda activate` is made available as a shell function which is not preserved when slurm executes a job.
+
+The suggestion of executing `conda init` **does not apply to Slurm**.
+Instead, an environment can be activated with one of the following methods:
+
+- Execute `conda activate` while logged into the submission node, then submit the job:
+
+  ```sh
+  $ conda activate myenv
+  (myenv) $ srun -N1 env | grep CONDA_PREFIX
+  CONDA_PREFIX=/homes/user/.conda/envs/myenv
+  ```
+
+- Execute `eval "$(conda shell.bash hook)"` as part of the slurm job in order to make `conda activate` available:
+
+  ```sh
+  $ cat run.sh
+  #!/usr/bin/env bash
+  #SBATCH -N1
+  eval "$(conda shell.bash hook)"
+  conda activate myenv
+  srun -N1 env | grep CONDA_PREFIX
+
+  $ sbatch run.sh
+
+  $ cat slurm-120651.out
+  CONDA_PREFIX=/homes/user/.conda/envs/myenv
+  ```
+
+[mambaforge]: https://github.com/conda-forge/miniforge#mambaforge

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -144,14 +144,15 @@ Your project coordinator can give you recommendations on where to run your jobs.
 
 We aim to keep the computing environments on the cluster as clean as possible. Therefore, only commonly used software packages are pre-installed and configured. At this moment this includes:
 
+- Slurm
 - Python 3
-- Conda
-- Docker (for applications with dependencies not available in the default set of software).
+- Mamba/Conda
+- Apptainer
 
-We assume basic familiarity with the tools above. If you want to learn more, you can take a look at following resources:
+We assume basic familiarity with the tools above. If you want to learn more, you can take a look at the following resources:
 
-- [Docker Curriculum](https://docker-curriculum.com)
 - [Conda Getting Started](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-conda)
+- [Apptainer User Guide](https://apptainer.org/docs/user/main/index.html)
 
 ## Where to store your data?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
   - Introduction: index.md
   - Getting Started: getting-started.md
   - User Guide:
+     - Conda: conda.md
      - Docker: docker.md
      - Jupyter Notebooks: jupyter.md
      - Troubleshooting: troubleshooting.md


### PR DESCRIPTION
This new page covers the issue that was brought up today in chat. I'm just glossing over Slurm, but covering that takes more time. While I was at it, I removed Docker from the list of installed software as it's not installed anymore on the Slurm cluster.