### PR TITLE
Transition from slurmq to shellhost

### DIFF
--- a/docs/apptainer.md
+++ b/docs/apptainer.md
@@ -2,6 +2,8 @@
 
 [Apptainer][apptainer] is the container system installed on the Slurm cluster. In contrast to Docker, it does not grant the user elevated privileges and is well-suited to multi-user environments. Nonetheless, it can run containers from Docker images as long as they do not depend on intrinsic root privileges such as binding to host ports below 1024.
 
+This document is not a comprehensive guide on Apptainer. To learn more, see the official manual.
+
 ## Basic commands
 
 Apptainer provides the following commands for launching containers:

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -3,7 +3,7 @@
 [Mambaforge][mambaforge] provides `mamba` and `conda` on the cluster.
 Users who prefer to manage their own installation can install a Conda distribution in their home directory.
 
-See [Getting started with conda][conda-getting-started] for an introduction.
+This document is not a comprehensive guide on Conda. To learn more, see the official manual.
 
 ## Using Conda with Slurm
 
@@ -23,7 +23,7 @@ This happens because `conda activate` is made available as a shell function whic
 The suggestion of executing `conda init` **does not apply to Slurm**.
 Instead, an environment can be activated with one of the following methods:
 
-- Execute `conda activate` while logged into the submission node, then submit the job:
+- Execute `conda activate` while logged into a submission node, then submit the job:
 
   ```sh
   $ conda activate myenv
@@ -47,5 +47,4 @@ Instead, an environment can be activated with one of the following methods:
   CONDA_PREFIX=/homes/user/.conda/envs/myenv
   ```
 
-[conda-getting-started]: https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-conda
 [mambaforge]: https://github.com/conda-forge/miniforge#mambaforge

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,7 @@ Host ikim
   IdentityFile ~/.ssh/id_ikim
   ForwardAgent yes
 
-Host g1-? c? c?? slurmq
+Host g1-? c? c?? shellhost
   Hostname %h.ikim.uk-essen.de
   User $USERNAME
   IdentityFile ~/.ssh/id_ikim
@@ -91,28 +91,19 @@ Host g1-? c? c?? slurmq
   ForwardAgent yes
 ```
 
-With `~/.ssh/config` in place, you can use the following command to log into any host, replacing `$HOSTNAME` appropriately.
-
-```sh
-ssh $HOSTNAME
-```
-
-The connection will transparently jump through the host labeled `ikim` and proceed to the target `$HOSTNAME`. The `ikim` host itself must _not_ be used for computational work.
-
 ### Test your SSH login
 
 Try the example below to test that your SSH client is properly configured:
 
 ```sh
-# Log into the slurm submission node
-ssh slurmq
+ssh ikim
 ```
 
-If the above is not working, please run the commands below and send the debug messages to your project coordinator for help.
+If it succeeds, type `exit` to log out. The `ikim` host must be used only for ssh authentication and _not_ for computational work; in fact, users should not log into it directly. Using the provided configuration file, ssh will automatically "jump through" the `ikim` host to reach the compute nodes.
 
-```sh
-ssh -v slurmq
-```
+For instructions on using the compute nodes, see the section [What software is available on the IKIM cluster?](#what-software-is-available-on-the-ikim-cluster)
+
+If the login test fails, please run the command below and send the output to your project coordinator for help.
 
 ```sh
 ssh -v ikim
@@ -141,18 +132,13 @@ A subset of these nodes are deployed as a Slurm cluster. Unless instructed other
 
 ## What software is available on the IKIM cluster?
 
-We aim to keep the computing environments on the cluster as clean as possible. Therefore, only commonly used software packages are pre-installed and configured. At this moment this includes:
+The main entrypoint to the cluster is Slurm. On compute nodes, we aim to keep the environment as clean as possible, therefore only commonly used software packages are pre-installed and configured. At this moment the list includes:
 
-- Slurm
 - Python 3
 - Mamba/Conda
 - Apptainer
 
-Comprehensive guides on these tools are outside the scope of this document. To learn more, see the following resources:
-
-- [Slurm](./slurm.md)
-- [Conda Getting Started](./conda.md)
-- [Apptainer User Guide](https://apptainer.org/docs/user/main/index.html)
+Introductory guides can be reached from the navigation pane.
 
 ## Where to store your data?
 

--- a/docs/jupyter.md
+++ b/docs/jupyter.md
@@ -4,10 +4,10 @@ The Jupyter Notebook is an open-source web application that allows creating and 
 
 ## Starting a Jupyter server instance
 
-To launch a Jupyter instance on the [Slurm](./slurm.md) cluster, first log into the Slurm submission node:
+To launch a Jupyter instance on the [Slurm](./slurm.md) cluster, first log into a Slurm submission node:
 
 ```sh
-ssh slurmq
+ssh shellhost
 ```
 
 Next, either create a conda environment with the package `notebook` from the channel `conda-forge` or install the package in an existing environment.
@@ -74,9 +74,7 @@ To verify that the notebook is running on the remote host and within the conda e
 
 ### From Visual Studio Code
 
-Connect to the Slurm submission node as described in [Connect to a remote host][vscode-docs-connect-ssh-host]. When prompted for the target host, type `slurmq`.
-
-From the submission node, connect to the Jupyter server as described in [Connect to a remote Jupyter server][vscode-docs-remote-jupyter]. When prompted for the URL, simply copy and paste the URL displayed in the output from `jupyter notebook`. As opposed to the browser method, in this case the connection originates from inside the cluster and there's no need to set up port forwarding.
+Connect to a Slurm submission node as described in [Connect to a remote host][vscode-docs-connect-ssh-host]. When prompted for the target host, type `shellhost`. From there, connect to the Jupyter server as described in [Connect to a remote Jupyter server][vscode-docs-remote-jupyter]. When prompted for the URL, simply copy and paste the URL displayed in the output from `jupyter notebook`. As opposed to the browser method, in this case the connection originates from inside the cluster and there's no need to set up port forwarding.
 
 [vscode-docs-connect-ssh-host]: https://code.visualstudio.com/docs/remote/ssh#_connect-to-a-remote-host
 [vscode-docs-remote-jupyter]: https://code.visualstudio.com/docs/datascience/jupyter-notebooks#_connect-to-a-remote-jupyter-server

--- a/docs/slurm.md
+++ b/docs/slurm.md
@@ -1,20 +1,29 @@
 # Slurm
 
-The entry point to the [Slurm][slurm-homepage] cluster is the job submission node:
+The entry point to the [Slurm][slurm-homepage] cluster is a set of nodes under the name `shellhost`. Before connecting, acquire the list of ssh host keys by executing:
 
 ```sh
-ssh slurmq
+ssh ikim resolvectl query shellhost.ikim.uk-essen.de | \
+    grep -E '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' --only-matching | \
+    sed -E 's/(.*)/\1 shellhost.ikim.uk-essen.de/' | \
+    ssh ikim ssh-keyscan -t ed25519 -f - >> ~/.ssh/known_hosts
 ```
 
-From the submission node, jobs (inline commands or scripts) can be submitted to worker nodes.
+Then connect to a submission node:
+
+```sh
+ssh shellhost
+```
+
+Jobs (inline commands or scripts) can be submitted to worker nodes from any of the submission nodes.
 
 Worker nodes are divided in groups called _partitions_ in Slurm terminology. The default partition is made up of general-purpose CPU nodes.
 
-See [Slurm quickstart][slurm-quickstart] for an introduction.
+This document is not a comprehensive guide on Slurm. To learn more, see the official manual.
 
 ## Client tools
 
-This is a brief overview of the main commands available on the submission node. They can also be invoked from worker nodes as part of a submitted job.
+This is a brief overview of the main commands available on the submission nodes. They can also be invoked from worker nodes as part of a submitted job.
 
 ### sinfo
 
@@ -208,5 +217,4 @@ If a job is expected to run continuously for many hours, a deadline should be sp
 It's good practice to always specify a deadline when opening a shell (`srun --pty bash`). This avoids the "hanging session" issue that occurs if the user forgets to log out or loses the connection abruptly.
 
 [slurm-homepage]: https://slurm.schedmd.com
-[slurm-quickstart]: https://slurm.schedmd.com/quickstart.html
 [sbatch-env]: https://slurm.schedmd.com/sbatch.html#SECTION_OUTPUT-ENVIRONMENT-VARIABLES


### PR DESCRIPTION
`shellhost` is a new hostname which corresponds to multiple hosts by means of round-robin DNS.